### PR TITLE
Add metrics logging and admin dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,17 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from "@/lib/auth";
+import { NotificationProvider } from "@/lib/notifications";
+import SystemAlerts from "@/components/system-alerts";
 
 import Home from "@/pages/home";
 import Profile from "@/pages/profile";
+import ProfileEdit from "@/pages/profile-edit";
 import Forum from "@/pages/forum";
+import MessagesPage from "@/pages/messages";
 import Auth from "@/pages/auth";
 import Dashboard from "@/pages/dashboard";
+import AdminDashboard from "@/pages/admin-dashboard";
 import NotFound from "@/pages/not-found";
 import Navbar from "@/components/navbar";
 import Footer from "@/components/footer";
@@ -23,14 +28,18 @@ function Router() {
   return (
     <div className="flex flex-col min-h-screen">
       {!isAuthPage && <Navbar />}
+      {!isAuthPage && <SystemAlerts />}
       
       <main className="flex-grow">
         <Switch>
           <Route path="/" component={Home} />
           <Route path="/dashboard" component={Dashboard} />
           <Route path="/profile" component={Profile} />
+          <Route path="/profile/edit" component={ProfileEdit} />
           <Route path="/forum" component={Forum} />
           <Route path="/forum/:subreddit" component={Forum} />
+          <Route path="/messages" component={MessagesPage} />
+          <Route path="/admin" component={AdminDashboard} />
           <Route path="/auth/:type" component={Auth} />
           <Route component={NotFound} />
         </Switch>
@@ -45,8 +54,10 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <Router />
-        <Toaster />
+        <NotificationProvider>
+          <Router />
+          <Toaster />
+        </NotificationProvider>
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/__tests__/health-visualization.test.ts
+++ b/client/src/components/__tests__/health-visualization.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { transformHealthData } from '../../lib/transformHealthData';
+
+function isoDaysAgo(days: number) {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString();
+}
+
+describe('transformHealthData', () => {
+  it('returns empty array when no stats provided', () => {
+    expect(transformHealthData([])).toEqual([]);
+  });
+
+  it('groups stats by date and parses values', () => {
+    const day1 = isoDaysAgo(1);
+    const day2 = isoDaysAgo(2);
+    const stats = [
+      { timestamp: day1, statType: 'heart_rate', value: '80' },
+      { timestamp: day1, statType: 'steps', value: '1000' },
+      { timestamp: day2, statType: 'sleep', value: '7.5' }
+    ];
+
+    const result = transformHealthData(stats);
+    const date1 = day1.split('T')[0];
+    const date2 = day2.split('T')[0];
+    const entry1 = result.find(d => d.date === date1);
+    const entry2 = result.find(d => d.date === date2);
+
+    expect(entry1).toMatchObject({ heartRate: 80, steps: 1000 });
+    expect(entry2).toMatchObject({ sleepHours: 7.5 });
+    expect(result.length).toBe(7);
+  });
+
+  it('handles undefined input', () => {
+    expect(transformHealthData(undefined as any)).toEqual([]);
+  });
+
+  it('ignores unknown stat types', () => {
+    const day = isoDaysAgo(1);
+    const stats = [
+      { timestamp: day, statType: 'unknown', value: '50' },
+      { timestamp: day, statType: 'steps', value: '500' }
+    ];
+
+    const result = transformHealthData(stats);
+    const entry = result.find(d => d.date === day.split('T')[0]);
+    expect(entry).toMatchObject({ steps: 500 });
+    expect((entry as any).unknown).toBeUndefined();
+  });
+
+  it('skips stats with invalid timestamps or values', () => {
+    const validDay = isoDaysAgo(1);
+    const stats = [
+      { timestamp: 'bad-date', statType: 'heart_rate', value: '80' },
+      { timestamp: validDay, statType: 'heart_rate', value: 'abc' },
+      { timestamp: validDay, statType: 'heart_rate', value: '70' }
+    ];
+
+    const result = transformHealthData(stats);
+    const entry = result.find(d => d.date === validDay.split('T')[0]);
+    expect(entry).toMatchObject({ heartRate: 70 });
+  });
+});

--- a/client/src/components/advanced-trend-analysis.tsx
+++ b/client/src/components/advanced-trend-analysis.tsx
@@ -1,0 +1,33 @@
+import { ResponsiveContainer, LineChart, CartesianGrid, XAxis, YAxis, Tooltip, Line } from 'recharts';
+import type { HealthDataPoint } from '@/lib/transformHealthData';
+
+interface Props {
+  data: HealthDataPoint[];
+}
+
+export default function AdvancedTrendAnalysis({ data }: Props) {
+  if (!data.length) return null;
+
+  const movingAverage = data.map((d, idx) => {
+    const slice = data.slice(Math.max(0, idx - 2), idx + 1);
+    const hrAvg = slice.reduce((sum, v) => sum + (v.heartRate || 0), 0) / slice.length;
+    return { date: d.date, hrAvg: parseFloat(hrAvg.toFixed(1)) };
+  });
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-lg font-semibold mb-2">Advanced Trend Analysis</h3>
+      <div className="h-[250px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={movingAverage}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="hrAvg" stroke="#10b981" name="Avg Heart Rate" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/connect-health-data.tsx
+++ b/client/src/components/connect-health-data.tsx
@@ -62,23 +62,32 @@ export default function ConnectHealthDataButton() {
   };
 
   function connectHealthData(providerId: string) {
-    // This would be replaced with actual implementation to connect to the health provider's API
+    const oauthMap: Record<string, string> = {
+      apple: 'apple-health',
+      google: 'google-fit',
+      fitbit: 'fitbit',
+    };
+
+    const route = oauthMap[providerId];
+    if (route) {
+      window.location.href = `/api/oauth/${route}`;
+      return;
+    }
+
+    // Fallback for providers without OAuth yet
     alert(`Connecting your health data for personal management from ${providerId}...`);
-    
-    // In a real implementation, this would redirect to the OAuth flow or API connection
     setTimeout(() => {
-      alert('Connection successful! Your health data will begin syncing shortly.');
       setOpen(false);
     }, 1500);
   }
 
   return (
     <>
-      <Button 
+      <Button
         onClick={() => setOpen(true)}
         className="bg-primary hover:bg-primary/90 text-white"
       >
-        <i className="ri-heart-pulse-line mr-2"></i>
+        <i className="ri-heart-pulse-line mr-2" aria-hidden="true"></i>
         Connect Health Data
       </Button>
 
@@ -101,7 +110,10 @@ export default function ConnectHealthDataButton() {
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between">
                     <CardTitle className="text-lg">{provider.name}</CardTitle>
-                    <i className={`${provider.logo} text-2xl text-primary`}></i>
+                    <i
+                      className={`${provider.logo} text-2xl text-primary`}
+                      aria-hidden="true"
+                    ></i>
                   </div>
                 </CardHeader>
                 <CardContent>

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -3,7 +3,7 @@ import { Link } from "wouter";
 const Footer = () => {
   return (
     <footer className="bg-gray-800 text-white py-12">
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
             <div className="flex items-center space-x-2 mb-4">
@@ -16,16 +16,20 @@ const Footer = () => {
             </p>
             <div className="flex space-x-4">
               <a href="#" className="text-gray-400 hover:text-primary">
-                <i className="ri-facebook-fill text-xl"></i>
+                <i className="ri-facebook-fill text-xl" aria-hidden="true"></i>
+                <span className="sr-only">Facebook</span>
               </a>
               <a href="#" className="text-gray-400 hover:text-primary">
-                <i className="ri-twitter-fill text-xl"></i>
+                <i className="ri-twitter-fill text-xl" aria-hidden="true"></i>
+                <span className="sr-only">Twitter</span>
               </a>
               <a href="#" className="text-gray-400 hover:text-primary">
-                <i className="ri-instagram-line text-xl"></i>
+                <i className="ri-instagram-line text-xl" aria-hidden="true"></i>
+                <span className="sr-only">Instagram</span>
               </a>
               <a href="#" className="text-gray-400 hover:text-primary">
-                <i className="ri-linkedin-fill text-xl"></i>
+                <i className="ri-linkedin-fill text-xl" aria-hidden="true"></i>
+                <span className="sr-only">LinkedIn</span>
               </a>
             </div>
           </div>

--- a/client/src/components/goal-tracker.tsx
+++ b/client/src/components/goal-tracker.tsx
@@ -1,40 +1,124 @@
 
-import { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
+import { useState, useEffect } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 
-interface Goal {
-  title: string;
-  current: number;
-  target: number;
-  unit: string;
+// Persist a numeric value in localStorage
+const usePersistedNumber = (key: string, initial: number) => {
+  const [value, setValue] = useState<number>(() => {
+    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null
+    return stored ? parseInt(stored, 10) : initial
+  })
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(key, String(value))
+    }
+  }, [key, value])
+
+  return [value, setValue] as const
 }
 
 export const GoalTracker = () => {
-  const [goals] = useState<Goal[]>([
-    { title: "Daily Steps", current: 8000, target: 10000, unit: "steps" },
-    { title: "Sleep", current: 7, target: 8, unit: "hours" },
-    { title: "Water Intake", current: 6, target: 8, unit: "glasses" }
-  ]);
+  const todayKey = new Date().toISOString().split('T')[0]
+
+  const [stepGoal, setStepGoal] = usePersistedNumber('stepGoal', 10000)
+  const [hydrationGoal, setHydrationGoal] = usePersistedNumber('hydrationGoal', 8)
+  const [stepsToday, setStepsToday] = usePersistedNumber(`steps_${todayKey}`, 0)
+  const [waterToday, setWaterToday] = usePersistedNumber(`water_${todayKey}`, 0)
+
+  const [stepInput, setStepInput] = useState('')
+  const [waterInput, setWaterInput] = useState('')
+
+  const addSteps = (e: React.FormEvent) => {
+    e.preventDefault()
+    const val = parseInt(stepInput, 10) || 0
+    setStepsToday((s) => s + val)
+    setStepInput('')
+  }
+
+  const addWater = (e: React.FormEvent) => {
+    e.preventDefault()
+    const val = parseInt(waterInput, 10) || 0
+    setWaterToday((w) => w + val)
+    setWaterInput('')
+  }
+
+  const stepProgress = Math.min((stepsToday / stepGoal) * 100, 100)
+  const waterProgress = Math.min((waterToday / hydrationGoal) * 100, 100)
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Health Goals</CardTitle>
+        <CardTitle>Daily Goals</CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          {goals.map((goal, index) => (
-            <div key={index} className="space-y-2">
-              <div className="flex justify-between text-sm">
-                <span>{goal.title}</span>
-                <span>{goal.current}/{goal.target} {goal.unit}</span>
-              </div>
-              <Progress value={(goal.current / goal.target) * 100} />
-            </div>
-          ))}
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <h4 className="font-medium">Steps</h4>
+          <div className="flex items-center space-x-2 mb-2">
+            <Input
+              type="number"
+              value={stepGoal}
+              onChange={(e) => setStepGoal(parseInt(e.target.value, 10) || 0)}
+              className="w-24"
+            />
+            <span className="text-sm text-muted-foreground">goal</span>
+          </div>
+          <form onSubmit={addSteps} className="flex items-center space-x-2 mb-2">
+            <Input
+              type="number"
+              value={stepInput}
+              onChange={(e) => setStepInput(e.target.value)}
+              placeholder="Add steps"
+              className="w-24"
+            />
+            <Button type="submit" variant="outline" size="sm">
+              Add
+            </Button>
+          </form>
+          <div className="flex justify-between text-sm">
+            <span>
+              {stepsToday}/{stepGoal} steps
+            </span>
+            <span>{Math.round(stepProgress)}%</span>
+          </div>
+          <Progress value={stepProgress} />
+        </div>
+
+        <div className="space-y-2">
+          <h4 className="font-medium">Hydration</h4>
+          <div className="flex items-center space-x-2 mb-2">
+            <Input
+              type="number"
+              value={hydrationGoal}
+              onChange={(e) => setHydrationGoal(parseInt(e.target.value, 10) || 0)}
+              className="w-24"
+            />
+            <span className="text-sm text-muted-foreground">glasses</span>
+          </div>
+          <form onSubmit={addWater} className="flex items-center space-x-2 mb-2">
+            <Input
+              type="number"
+              value={waterInput}
+              onChange={(e) => setWaterInput(e.target.value)}
+              placeholder="Add glasses"
+              className="w-24"
+            />
+            <Button type="submit" variant="outline" size="sm">
+              Add
+            </Button>
+          </form>
+          <div className="flex justify-between text-sm">
+            <span>
+              {waterToday}/{hydrationGoal} glasses
+            </span>
+            <span>{Math.round(waterProgress)}%</span>
+          </div>
+          <Progress value={waterProgress} />
         </div>
       </CardContent>
     </Card>
-  );
-};
+  )
+}

--- a/client/src/components/health-stat-card.tsx
+++ b/client/src/components/health-stat-card.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+interface HealthStatCardProps {
+  title: string;
+  value: string | number;
+  unit?: string;
+  icon?: string; // optional icon class e.g. 'ri-walk-line'
+  className?: string;
+}
+
+const HealthStatCard = ({ title, value, unit, icon, className }: HealthStatCardProps) => {
+  return (
+    <Card className={cn('flex items-center', className)}>
+      <CardContent className="p-4 flex items-center gap-4">
+        {icon && <i className={`${icon} text-2xl text-primary`} aria-hidden="true" />}
+        <div>
+          <p className="text-sm text-gray-600">{title}</p>
+          <div className="flex items-baseline">
+            <span className="text-2xl font-bold">{value}</span>
+            {unit && <span className="ml-1 text-sm text-gray-500">{unit}</span>}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default HealthStatCard;

--- a/client/src/components/health-visualization.tsx
+++ b/client/src/components/health-visualization.tsx
@@ -1,6 +1,6 @@
 
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useFetchWithFallback } from '@/hooks/use-fetch-with-fallback';
 import { 
   LineChart, 
   Line, 
@@ -19,81 +19,16 @@ import {
   Bar
 } from 'recharts';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
+import HealthStatCard from './health-stat-card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
+import { transformHealthData } from '@/lib/transformHealthData';
+import { useAuth } from '@/lib/auth';
+import { hasFeature } from '@/lib/featureFlags';
+import { downloadCSV } from '@/lib/utils';
+import AdvancedTrendAnalysis from './advanced-trend-analysis';
 
-// For calculating date ranges
-const getLastNDays = (n: number) => {
-  const result = [];
-  for (let i = n - 1; i >= 0; i--) {
-    const date = new Date();
-    date.setDate(date.getDate() - i);
-    result.push(date.toISOString().split('T')[0]);
-  }
-  return result;
-};
-
-// Type definition for our health data
-interface HealthDataPoint {
-  date: string;
-  heartRate?: number;
-  steps?: number;
-  sleepHours?: number;
-  bloodPressureSystolic?: number;
-  bloodPressureDiastolic?: number;
-  weight?: number;
-  calories?: number;
-  stressLevel?: number;
-}
-
-// Transform health stats from API to visualization data format
-const transformHealthData = (healthStats: any[] = []): HealthDataPoint[] => {
-  if (!healthStats.length) return [];
-  
-  // Get all dates in the last 7 days
-  const dates = getLastNDays(7);
-  
-  // Create a map to organize stats by date
-  const statsByDate = new Map<string, HealthDataPoint>();
-  
-  // Initialize with empty data points for all dates
-  dates.forEach(date => {
-    statsByDate.set(date, { date });
-  });
-  
-  // Fill in actual data where available
-  healthStats.forEach(stat => {
-    const date = new Date(stat.timestamp).toISOString().split('T')[0];
-    const existingData = statsByDate.get(date) || { date };
-    
-    // Map the various stat types to our data structure
-    if (stat.statType === 'heart_rate') {
-      existingData.heartRate = parseFloat(stat.value);
-    } else if (stat.statType === 'steps') {
-      existingData.steps = parseFloat(stat.value);
-    } else if (stat.statType === 'sleep') {
-      existingData.sleepHours = parseFloat(stat.value);
-    } else if (stat.statType === 'blood_pressure') {
-      const [systolic, diastolic] = stat.value.split('/').map((v: string) => parseFloat(v.trim()));
-      existingData.bloodPressureSystolic = systolic;
-      existingData.bloodPressureDiastolic = diastolic;
-    } else if (stat.statType === 'weight') {
-      existingData.weight = parseFloat(stat.value);
-    } else if (stat.statType === 'calories') {
-      existingData.calories = parseFloat(stat.value);
-    } else if (stat.statType === 'stress') {
-      existingData.stressLevel = parseFloat(stat.value);
-    }
-    
-    statsByDate.set(date, existingData);
-  });
-  
-  // Convert map back to array and sort by date
-  return Array.from(statsByDate.values()).sort((a, b) => 
-    new Date(a.date).getTime() - new Date(b.date).getTime()
-  );
-};
 
 // Create custom tooltip component
 const CustomTooltip = ({ active, payload, label }: any) => {
@@ -129,12 +64,18 @@ type VisualizationType = 'line' | 'area' | 'bar' | 'pie';
 export default function HealthVisualization() {
   const [visualizationType, setVisualizationType] = useState<VisualizationType>('line');
   const [timeRange, setTimeRange] = useState<'7days' | '30days' | '90days'>('7days');
+  const { user } = useAuth();
+  const canAdvanced = hasFeature(user, 'advancedTrendAnalysis');
+  const canExportCsv = hasFeature(user, 'exportCsv');
   
   // Fetch health data from API
-  const { data: healthStats, isLoading, isError } = useQuery({
-    queryKey: ['/api/health/stats'],
-    refetchOnWindowFocus: false
-  });
+  const {
+    data: healthStats,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useFetchWithFallback<any[]>('/api/health/stats', []);
   
   // Transform the data for visualization
   const chartData = transformHealthData(healthStats as any[]);
@@ -195,12 +136,28 @@ export default function HealthVisualization() {
         <CardHeader>
           <CardTitle>Health Trends</CardTitle>
           <CardDescription className="text-red-500">
-            Failed to load health data. Please try again later.
+            {`Failed to load health data${error ? `: ${error.message}` : ''}.`}
           </CardDescription>
         </CardHeader>
         <CardContent className="flex justify-center">
-          <Button variant="outline" onClick={() => window.location.reload()}>
+          <Button variant="outline" onClick={() => refetch()}>
             Retry
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!chartData.length) {
+    return (
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Health Trends</CardTitle>
+          <CardDescription>No health data available yet.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button variant="outline" onClick={() => refetch()}>
+            Refresh
           </Button>
         </CardContent>
       </Card>
@@ -257,58 +214,62 @@ export default function HealthVisualization() {
           >
             <i className="ri-bar-chart-horizontal-line mr-1"></i> Bar
           </Button>
-          <Button 
-            variant={visualizationType === 'pie' ? 'default' : 'outline'} 
-            size="sm" 
+          <Button
+            variant={visualizationType === 'pie' ? 'default' : 'outline'}
+            size="sm"
             onClick={() => setVisualizationType('pie')}
             className="text-xs"
           >
             <i className="ri-pie-chart-line mr-1"></i> Pie
           </Button>
+          {canExportCsv ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => downloadCSV(chartData, 'health-stats.csv')}
+              className="text-xs"
+            >
+              <i className="ri-download-line mr-1"></i> Export CSV
+            </Button>
+          ) : (
+            <Button variant="outline" size="sm" disabled className="text-xs opacity-60 cursor-not-allowed">
+              Export CSV
+            </Button>
+          )}
         </div>
         
         {/* Summary Statistics */}
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-          <Card className="bg-primary/5">
-            <CardContent className="p-4 flex flex-col items-center justify-center">
-              <span className="text-sm text-gray-600">Avg. Heart Rate</span>
-              <div className="flex items-baseline">
-                <span className="text-3xl font-bold text-primary">{summary.avgHeartRate || 'N/A'}</span>
-                <span className="text-sm text-gray-500 ml-1">BPM</span>
-              </div>
-            </CardContent>
-          </Card>
-          
-          <Card className="bg-blue-50">
-            <CardContent className="p-4 flex flex-col items-center justify-center">
-              <span className="text-sm text-gray-600">Total Steps</span>
-              <div className="flex items-baseline">
-                <span className="text-3xl font-bold text-blue-500">
-                  {summary.totalSteps ? summary.totalSteps.toLocaleString() : 'N/A'}
-                </span>
-              </div>
-            </CardContent>
-          </Card>
-          
-          <Card className="bg-indigo-50">
-            <CardContent className="p-4 flex flex-col items-center justify-center">
-              <span className="text-sm text-gray-600">Avg. Sleep</span>
-              <div className="flex items-baseline">
-                <span className="text-3xl font-bold text-indigo-500">{summary.avgSleep || 'N/A'}</span>
-                <span className="text-sm text-gray-500 ml-1">hrs</span>
-              </div>
-            </CardContent>
-          </Card>
-          
-          <Card className="bg-orange-50">
-            <CardContent className="p-4 flex flex-col items-center justify-center">
-              <span className="text-sm text-gray-600">Avg. Stress</span>
-              <div className="flex items-baseline">
-                <span className="text-3xl font-bold text-orange-500">{summary.avgStressLevel || 'N/A'}</span>
-                <span className="text-sm text-gray-500 ml-1">/10</span>
-              </div>
-            </CardContent>
-          </Card>
+          <HealthStatCard
+            title="Avg. Heart Rate"
+            value={summary.avgHeartRate ?? 'N/A'}
+            unit="BPM"
+            icon="ri-heart-pulse-line"
+            className="bg-primary/5"
+          />
+
+          <HealthStatCard
+            title="Total Steps"
+            value={summary.totalSteps ? summary.totalSteps.toLocaleString() : 'N/A'}
+            icon="ri-walk-line"
+            className="bg-blue-50"
+          />
+
+          <HealthStatCard
+            title="Avg. Sleep"
+            value={summary.avgSleep ?? 'N/A'}
+            unit="hrs"
+            icon="ri-zzz-line"
+            className="bg-indigo-50"
+          />
+
+          <HealthStatCard
+            title="Avg. Stress"
+            value={summary.avgStressLevel ?? 'N/A'}
+            unit="/10"
+            icon="ri-emotion-line"
+            className="bg-orange-50"
+          />
         </div>
         
         {/* Visualization Chart */}
@@ -465,6 +426,7 @@ export default function HealthVisualization() {
             </ResponsiveContainer>
           ) : null}
         </div>
+        {canAdvanced && <AdvancedTrendAnalysis data={chartData} />}
       </CardContent>
     </Card>
   );

--- a/client/src/components/medication-tracker.tsx
+++ b/client/src/components/medication-tracker.tsx
@@ -10,6 +10,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { format, parseISO, isToday, isTomorrow, addDays } from "date-fns";
+import { getAuthToken } from "../lib/utils";
 
 interface Medication {
   id: number;
@@ -53,7 +54,7 @@ const MedicationTracker = () => {
 
   const handleMedicationTaken = async (id: number) => {
     try {
-      const token = localStorage.getItem('token');
+      const token = getAuthToken();
       await fetch(`/api/medications/${id}/take`, {
         method: 'POST',
         headers: { 
@@ -70,7 +71,7 @@ const MedicationTracker = () => {
 
   const handleAddMedication = async (values: MedicationFormValues) => {
     try {
-      const token = localStorage.getItem('token');
+      const token = getAuthToken();
       await fetch('/api/medications', {
         method: 'POST',
         headers: { 

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "wouter";
 import { useAuth } from "@/lib/auth";
+import { useNotifications } from "@/lib/notifications";
+import { useDarkMode } from "@/hooks/useDarkMode";
+import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,12 +11,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ChevronDown, Menu } from "lucide-react";
+import { ChevronDown, Menu, Moon, Sun } from "lucide-react";
 
 const Navbar = () => {
   const [location] = useLocation();
   const { user, logout } = useAuth();
+  const { unreadCount } = useNotifications();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const { isDark, toggle } = useDarkMode();
 
   const handleLogout = () => {
     logout();
@@ -26,16 +31,20 @@ const Navbar = () => {
 
   return (
     <header className="bg-white shadow-md sticky top-0 z-50">
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center space-x-2">
-            <i className="ri-heart-pulse-line text-primary text-2xl"></i>
+            <i className="ri-heart-pulse-line text-primary text-2xl" aria-hidden="true"></i>
             <Link href="/" className="text-xl font-heading font-bold text-gray-800">
               Healthmap
             </Link>
           </div>
 
-          <div className="hidden md:flex items-center space-x-6">
+          <nav
+            role="navigation"
+            aria-label="main"
+            className="hidden md:flex items-center space-x-6"
+          >
             <Link
               href="/"
               className={`text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
@@ -61,6 +70,27 @@ const Navbar = () => {
               Profile
             </Link>
             <Link
+              href="/messages"
+              className={`relative text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
+                location.startsWith("/messages") ? "text-primary" : ""
+              }`}
+            >
+              Messages
+              {unreadCount > 0 && (
+                <Badge className="absolute -top-2 -right-3" variant="destructive">
+                  {unreadCount}
+                </Badge>
+              )}
+            </Link>
+            <Link
+              href="/admin"
+              className={`text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
+                location === "/admin" ? "text-primary" : ""
+              }`}
+            >
+              Admin
+            </Link>
+            <Link
               href="/forum"
               className={`text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
                 location.startsWith("/forum") ? "text-primary" : ""
@@ -68,7 +98,7 @@ const Navbar = () => {
             >
               Forum
             </Link>
-          </div>
+          </nav>
 
           <div className="flex items-center space-x-4">
             {user ? (
@@ -117,10 +147,25 @@ const Navbar = () => {
             )}
 
             <button
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="md:hidden text-gray-700 focus:outline-none"
+              onClick={toggle}
+              aria-label="Toggle dark mode"
+              className="text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
             >
-              <Menu className="h-6 w-6" />
+              {isDark ? (
+                <Sun className="h-5 w-5" aria-hidden="true" />
+              ) : (
+                <Moon className="h-5 w-5" aria-hidden="true" />
+              )}
+            </button>
+
+            <button
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+              aria-label="Toggle menu"
+              aria-expanded={isMobileMenuOpen}
+              className="md:hidden text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+            >
+              <Menu className="h-6 w-6" aria-hidden="true" />
+              <span className="sr-only">Toggle navigation menu</span>
             </button>
           </div>
         </div>
@@ -128,7 +173,11 @@ const Navbar = () => {
         {/* Mobile menu */}
         {isMobileMenuOpen && (
           <div className="md:hidden py-4 border-t border-gray-200">
-            <nav className="flex flex-col space-y-4">
+            <nav
+              role="navigation"
+              aria-label="mobile"
+              className="flex flex-col space-y-4"
+            >
               <Link
                 href="/"
                 className={`text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
@@ -152,6 +201,27 @@ const Navbar = () => {
                 }`}
               >
                 Profile
+              </Link>
+              <Link
+                href="/messages"
+                className={`relative text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
+                  location.startsWith("/messages") ? "text-primary" : ""
+                }`}
+              >
+                Messages
+                {unreadCount > 0 && (
+                  <Badge className="absolute -top-2 -right-3" variant="destructive">
+                    {unreadCount}
+                  </Badge>
+                )}
+              </Link>
+              <Link
+                href="/admin"
+                className={`text-gray-700 hover:text-primary transition-colors duration-200 font-medium ${
+                  location === "/admin" ? "text-primary" : ""
+                }`}
+              >
+                Admin
               </Link>
               <Link
                 href="/forum"

--- a/client/src/components/system-alerts.tsx
+++ b/client/src/components/system-alerts.tsx
@@ -1,0 +1,19 @@
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { useNotifications } from '@/lib/notifications';
+
+export default function SystemAlerts() {
+  const { alerts } = useNotifications();
+
+  if (!alerts.length) return null;
+
+  return (
+    <div className="p-2 space-y-2">
+      {alerts.map(alert => (
+        <Alert key={alert.id} variant="destructive">
+          <AlertTitle>{alert.title}</AlertTitle>
+          <AlertDescription>{alert.content}</AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/client/src/hooks/use-fetch-with-fallback.ts
+++ b/client/src/hooks/use-fetch-with-fallback.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getAuthToken } from '@/lib/utils';
+
+export interface FetchResult<T> {
+  data: T;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useFetchWithFallback<T>(
+  url: string,
+  fallbackData: T,
+  options?: RequestInit,
+): FetchResult<T> {
+  const [data, setData] = useState<T>(fallbackData);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const headers: HeadersInit = { 'Content-Type': 'application/json' };
+      const token = getAuthToken();
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+
+      const res = await fetch(url, { ...options, headers });
+      if (!res.ok) {
+        const text = (await res.text()) || res.statusText;
+        throw new Error(`${res.status}: ${text}`);
+      }
+      const json = (await res.json()) as T;
+      setData(json);
+    } catch (err) {
+      console.error('Fetch failed:', err);
+      setError(err as Error);
+      setData(fallbackData);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [url, options, fallbackData]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    data,
+    isLoading,
+    isError: Boolean(error),
+    error,
+    refetch: fetchData,
+  };
+}

--- a/client/src/hooks/useDarkMode.ts
+++ b/client/src/hooks/useDarkMode.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "theme";
+
+export function useDarkMode() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    const prefers = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const enabled = saved ? saved === "dark" : prefers;
+    setIsDark(enabled);
+    if (enabled) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, []);
+
+  const toggle = () => {
+    setIsDark((prev) => {
+      const next = !prev;
+      if (next) {
+        document.documentElement.classList.add("dark");
+        localStorage.setItem(STORAGE_KEY, "dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+        localStorage.setItem(STORAGE_KEY, "light");
+      }
+      return next;
+    });
+  };
+
+  return { isDark, toggle };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,6 +13,10 @@
   body {
     @apply font-sans antialiased bg-background text-foreground;
   }
+
+  .dark body {
+    @apply bg-gray-900 text-gray-100;
+  }
   
   h1, h2, h3, h4, h5, h6 {
     @apply font-heading text-dark-text;

--- a/client/src/lib/featureFlags.ts
+++ b/client/src/lib/featureFlags.ts
@@ -1,0 +1,1 @@
+export { hasFeature, PremiumFeatures, type PremiumFeatureKey } from '@shared/featureFlags';

--- a/client/src/lib/notifications.tsx
+++ b/client/src/lib/notifications.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { apiRequest } from './queryClient';
+
+export interface SystemAlert {
+  id: number;
+  title: string;
+  content: string;
+  timestamp: string;
+  category: string;
+}
+
+interface NotificationContextType {
+  unreadCount: number;
+  alerts: SystemAlert[];
+  refresh: () => Promise<void>;
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+export const NotificationProvider = ({ children }: { children: ReactNode }) => {
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [alerts, setAlerts] = useState<SystemAlert[]>([]);
+
+  const fetchData = async () => {
+    try {
+      const res = await apiRequest('GET', '/api/messages/unread-count');
+      const data = await res.json();
+      setUnreadCount(data.count || 0);
+    } catch (err) {
+      console.error('Failed to load unread count', err);
+    }
+
+    try {
+      const res = await apiRequest('GET', '/api/alerts');
+      const data = await res.json();
+      setAlerts(data);
+    } catch (err) {
+      console.error('Failed to load alerts', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <NotificationContext.Provider value={{ unreadCount, alerts, refresh: fetchData }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotifications = (): NotificationContextType => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error('useNotifications must be used within a NotificationProvider');
+  }
+  return ctx;
+};

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { getAuthToken } from "./utils";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -18,7 +19,7 @@ export async function apiRequest(
   };
   
   // Add authorization header if token exists
-  const token = localStorage.getItem("auth_token");
+  const token = getAuthToken();
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
@@ -55,7 +56,7 @@ export const getQueryFn: <T>(options: {
     };
     
     // Add authorization header if token exists
-    const token = localStorage.getItem("auth_token");
+    const token = getAuthToken();
     if (token) {
       headers["Authorization"] = `Bearer ${token}`;
     }

--- a/client/src/lib/transformHealthData.ts
+++ b/client/src/lib/transformHealthData.ts
@@ -1,0 +1,74 @@
+export interface HealthDataPoint {
+  date: string;
+  heartRate?: number;
+  steps?: number;
+  sleepHours?: number;
+  bloodPressureSystolic?: number;
+  bloodPressureDiastolic?: number;
+  weight?: number;
+  calories?: number;
+  stressLevel?: number;
+}
+
+const getLastNDays = (n: number) => {
+  const result = [] as string[];
+  for (let i = n - 1; i >= 0; i--) {
+    const date = new Date();
+    date.setDate(date.getDate() - i);
+    result.push(date.toISOString().split('T')[0]);
+  }
+  return result;
+};
+
+export const transformHealthData = (healthStats: any[] = []): HealthDataPoint[] => {
+  if (!Array.isArray(healthStats) || !healthStats.length) return [];
+
+  const dates = getLastNDays(7);
+  const statsByDate = new Map<string, HealthDataPoint>();
+
+  dates.forEach(date => {
+    statsByDate.set(date, { date });
+  });
+
+  healthStats.forEach(stat => {
+    if (!stat || !stat.timestamp) return;
+    const dateObj = new Date(stat.timestamp);
+    if (isNaN(dateObj.getTime())) return;
+    const date = dateObj.toISOString().split('T')[0];
+    const existingData = statsByDate.get(date) || { date };
+
+    if (stat.statType === 'heart_rate') {
+      const val = parseFloat(stat.value);
+      if (!isNaN(val)) existingData.heartRate = val;
+    } else if (stat.statType === 'steps') {
+      const val = parseFloat(stat.value);
+      if (!isNaN(val)) existingData.steps = val;
+    } else if (stat.statType === 'sleep') {
+      const val = parseFloat(stat.value);
+      if (!isNaN(val)) existingData.sleepHours = val;
+    } else if (stat.statType === 'blood_pressure') {
+      if (typeof stat.value === 'string') {
+        const [systolic, diastolic] = stat.value
+          .split('/')
+          .map((v: string) => parseFloat(v.trim()));
+        if (!isNaN(systolic)) existingData.bloodPressureSystolic = systolic;
+        if (!isNaN(diastolic)) existingData.bloodPressureDiastolic = diastolic;
+      }
+    } else if (stat.statType === 'weight') {
+      const val = parseFloat(stat.value);
+      if (!isNaN(val)) existingData.weight = val;
+    } else if (stat.statType === 'calories') {
+      const val = parseFloat(stat.value);
+      if (!isNaN(val)) existingData.calories = val;
+    } else if (stat.statType === 'stress') {
+      const val = parseFloat(stat.value);
+      if (!isNaN(val)) existingData.stressLevel = val;
+    }
+
+    statsByDate.set(date, existingData);
+  });
+
+  return Array.from(statsByDate.values()).sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+};

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getAuthToken(): string | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage.getItem("auth_token");
+}
+
+export function downloadCSV(data: Record<string, any>[], filename = 'data.csv') {
+  if (!data.length) return;
+  const headers = Object.keys(data[0]).join(',');
+  const rows = data.map((row) => Object.values(row).join(',')).join('\n');
+  const csv = headers + '\n' + rows;
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+
+interface Metrics {
+  activeUsers: number;
+  syncCount: number;
+  topActions: Record<string, number>;
+}
+
+export default function AdminDashboard() {
+  const { data } = useQuery<Metrics>({ queryKey: ['/api/admin/metrics'] });
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  const actionsData = Object.entries(data.topActions).map(([action, count]) => ({ action, count }));
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Platform Metrics</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>Active Sessions: {data.activeUsers}</p>
+          <p>Total Health Syncs: {data.syncCount}</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Popular Actions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={actionsData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="action" />
+              <YAxis allowDecimals={false} />
+              <Tooltip />
+              <Bar dataKey="count" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -82,7 +82,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="container py-6 space-y-6">
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-bold tracking-tight">Health Dashboard</h1>
         <p className="text-muted-foreground">
@@ -91,7 +91,7 @@ export default function Dashboard() {
       </div>
 
       <Tabs defaultValue="overview" value={activeTab} onValueChange={setActiveTab} className="space-y-4">
-        <TabsList>
+        <TabsList className="overflow-x-auto whitespace-nowrap">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="journey">Health Journey</TabsTrigger>
           <TabsTrigger value="challenges">Challenges</TabsTrigger>
@@ -104,7 +104,7 @@ export default function Dashboard() {
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-6">
           {/* Simplified stats section */}
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <Card className="flex flex-row items-center p-4">
               <div className="rounded-full p-2 bg-primary/10 mr-3">
                 <Clock className="h-5 w-5 text-primary" />
@@ -147,7 +147,7 @@ export default function Dashboard() {
           </div>
 
           {/* Main sections */}
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid gap-6 sm:grid-cols-2">
             {/* Recent journey entries */}
             <Card className="col-span-1">
               <CardHeader className="pb-3">
@@ -229,7 +229,7 @@ export default function Dashboard() {
               </div>
             </CardHeader>
             <CardContent>
-              <div className="grid gap-6 md:grid-cols-2">
+              <div className="grid gap-6 sm:grid-cols-2">
                 {healthArticles.slice(0, 2).map((article: HealthArticle) => (
                   <div key={article.id} className="flex space-x-4 items-start">
                     {article.imageUrl && (
@@ -319,7 +319,7 @@ export default function Dashboard() {
 
         {/* Challenges Tab */}
         <TabsContent value="challenges" className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 sm:grid-cols-2">
             <Card>
               <CardHeader>
                 <CardTitle>Your Active Challenges</CardTitle>
@@ -448,7 +448,7 @@ export default function Dashboard() {
                     <Progress value={plan.progress} className="h-2" />
                   </div>
                   
-                  <div className="grid md:grid-cols-2 gap-4">
+                  <div className="grid sm:grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <h4 className="text-sm font-medium">Goals</h4>
                       <ul className="space-y-1">

--- a/client/src/pages/forum.tsx
+++ b/client/src/pages/forum.tsx
@@ -95,7 +95,7 @@ const Forum = () => {
   };
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="flex flex-col md:flex-row gap-8">
         {/* Forum Sidebar */}
         <div className="md:w-1/3 lg:w-1/4">

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -22,7 +22,7 @@ const Home = () => {
   });
 
   return (
-    <div className="container mx-auto px-4 py-6">
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6">
       <section id="home" className="py-8">
         {/* Hero Section */}
         <div className="bg-gradient-to-r from-primary to-secondary rounded-2xl overflow-hidden shadow-lg mb-12">

--- a/client/src/pages/messages.tsx
+++ b/client/src/pages/messages.tsx
@@ -1,0 +1,133 @@
+import { useState, useEffect } from 'react';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/lib/auth';
+import { apiRequest } from '@/lib/queryClient';
+import { useNotifications } from '@/lib/notifications';
+
+interface Message {
+  id: number;
+  senderId: number;
+  recipientId: number;
+  content: string;
+  timestamp: string;
+}
+
+export default function MessagesPage() {
+  const { user } = useAuth();
+  const { refresh } = useNotifications();
+  const [recipientId, setRecipientId] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!recipientId) return;
+    const fetchMessages = async () => {
+      try {
+        const res = await apiRequest('GET', `/api/messages/${recipientId}`);
+        const data = await res.json();
+        setMessages(data);
+        refresh();
+      } catch (err) {
+        console.error('Failed to fetch messages', err);
+      }
+    };
+    fetchMessages();
+    const id = setInterval(fetchMessages, 5000);
+    return () => clearInterval(id);
+  }, [recipientId]);
+
+  const sendMessage = async () => {
+    if (!message.trim() || !recipientId) return;
+    try {
+      await apiRequest('POST', '/api/messages', {
+        recipientId: parseInt(recipientId),
+        content: message,
+      });
+      setMessage('');
+      const res = await apiRequest('GET', `/api/messages/${recipientId}`);
+      const data = await res.json();
+      setMessages(data);
+      refresh();
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+  };
+
+  const blockCurrentUser = async () => {
+    if (!recipientId) return;
+    try {
+      await apiRequest('POST', '/api/block', { blockedId: parseInt(recipientId) });
+    } catch (err) {
+      console.error('Failed to block user', err);
+    }
+  };
+
+  const reportMessage = async (id: number) => {
+    try {
+      await apiRequest('POST', `/api/messages/${id}/report`, { reason: 'inappropriate' });
+    } catch (err) {
+      console.error('Failed to report message', err);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
+      <Card>
+        <CardHeader className="flex justify-between items-center">
+          <CardTitle>Inbox</CardTitle>
+          {recipientId && (
+            <Button variant="outline" size="sm" onClick={blockCurrentUser}>
+              Block User
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center space-x-2">
+            <Input
+              placeholder="Recipient ID"
+              value={recipientId}
+              onChange={(e) => setRecipientId(e.target.value)}
+              className="w-32"
+            />
+            <Button onClick={() => setRecipientId(recipientId)}>Open</Button>
+          </div>
+          <div className="max-h-64 overflow-y-auto space-y-2 border p-2">
+            {messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex flex-col ${msg.senderId === user?.id ? 'items-end' : 'items-start'}`}
+              >
+                <div
+                  className={`p-2 rounded-lg ${msg.senderId === user?.id ? 'bg-primary text-white rounded-tr-none' : 'bg-gray-100 text-gray-800 rounded-tl-none'}`}
+                >
+                  <p className="text-sm">{msg.content}</p>
+                  <p className="text-xs opacity-70 mt-1 text-right">
+                    {new Intl.DateTimeFormat('en-US', { hour: '2-digit', minute: '2-digit' }).format(
+                      new Date(msg.timestamp),
+                    )}
+                  </p>
+                </div>
+                {msg.senderId !== user?.id && (
+                  <Button variant="ghost" size="xs" onClick={() => reportMessage(msg.id)}>
+                    Report
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+        <CardFooter className="space-x-2">
+          <Input
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Type a message"
+            className="flex-1"
+          />
+          <Button onClick={sendMessage}>Send</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/profile-edit.tsx
+++ b/client/src/pages/profile-edit.tsx
@@ -1,0 +1,85 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Form, FormField, FormItem, FormLabel, FormControl } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/auth";
+import { useLocation } from "wouter";
+
+const profileSchema = z.object({
+  name: z.string().min(1, { message: "Name is required" }),
+  age: z.coerce.number().int().positive().optional(),
+  healthGoals: z.string().optional(),
+});
+
+type ProfileForm = z.infer<typeof profileSchema>;
+
+export default function ProfileEdit() {
+  const { user, updateProfile } = useAuth();
+  const [, setLocation] = useLocation();
+
+  const form = useForm<ProfileForm>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      name: user?.name || "",
+      age: user?.age as number | undefined,
+      healthGoals: user?.healthGoals || "",
+    },
+  });
+
+  const onSubmit = async (values: ProfileForm) => {
+    await updateProfile(values);
+    setLocation("/profile");
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="container mx-auto max-w-md px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-2xl font-heading mb-4">Edit Profile</h1>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="age"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Age</FormLabel>
+                <FormControl>
+                  <Input type="number" {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="healthGoals"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Health Goals</FormLabel>
+                <FormControl>
+                  <Textarea rows={3} {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <Button type="submit">Save</Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -53,7 +53,7 @@ const Profile = () => {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="flex flex-col md:flex-row gap-8">
         {/* Profile Sidebar */}
         <div className="md:w-1/3 lg:w-1/4">
@@ -66,9 +66,12 @@ const Profile = () => {
               />
               <h2 className="text-xl font-medium">{user.name}</h2>
               <p className="text-gray-500">{user.email}</p>
-              <button className="mt-4 w-full bg-white text-primary border border-primary font-medium py-2 rounded-md hover:bg-primary/5 transition-colors duration-200">
+              <Link
+                href="/profile/edit"
+                className="mt-4 w-full bg-white text-primary border border-primary font-medium py-2 rounded-md hover:bg-primary/5 transition-colors duration-200 text-center"
+              >
                 Edit Profile
-              </button>
+              </Link>
             </div>
 
             <div className="border-t border-gray-200 pt-4">
@@ -260,6 +263,9 @@ const Profile = () => {
                   Connect and manage your health data from various sources.
                 </p>
                 <HealthStats userId={user.id} detailed={true} />
+                <div className="mt-8">
+                  <HealthVisualization />
+                </div>
               </div>
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/mocks/apple-health.json
+++ b/mocks/apple-health.json
@@ -1,0 +1,14 @@
+[
+  {
+    "statType": "steps",
+    "value": "1200",
+    "unit": "count",
+    "timestamp": "2024-05-10T08:00:00Z"
+  },
+  {
+    "statType": "heart_rate",
+    "value": "72",
+    "unit": "bpm",
+    "timestamp": "2024-05-10T08:05:00Z"
+  }
+]

--- a/mocks/fitbit.json
+++ b/mocks/fitbit.json
@@ -1,0 +1,14 @@
+[
+  {
+    "statType": "steps",
+    "value": "4500",
+    "unit": "count",
+    "timestamp": "2024-05-10T12:00:00Z"
+  },
+  {
+    "statType": "sleep",
+    "value": "7.25",
+    "unit": "hrs",
+    "timestamp": "2024-05-09T23:00:00Z"
+  }
+]

--- a/mocks/google-fit.json
+++ b/mocks/google-fit.json
@@ -1,0 +1,14 @@
+[
+  {
+    "statType": "steps",
+    "value": "3000",
+    "unit": "count",
+    "timestamp": "2024-05-10T10:00:00Z"
+  },
+  {
+    "statType": "heart_rate",
+    "value": "68",
+    "unit": "bpm",
+    "timestamp": "2024-05-10T10:05:00Z"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
+        "nodemailer": "^6.9.11",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "react": "^18.3.1",
@@ -71,6 +72,7 @@
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.0",
+        "winston": "^3.10.0",
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
         "zod": "^3.23.8",
@@ -90,14 +92,17 @@
         "@types/react-dom": "^18.3.1",
         "@types/ws": "^8.5.13",
         "@vitejs/plugin-react": "^4.3.2",
+        "@vitest/coverage-v8": "^3.2.2",
         "autoprefixer": "^10.4.20",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "postcss": "^8.4.47",
+        "supertest": "^7.1.1",
         "tailwindcss": "^3.4.14",
         "tsx": "^4.19.1",
         "typescript": "5.6.3",
-        "vite": "^5.4.14"
+        "vite": "^5.4.14",
+        "vitest": "^3.2.1"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.8"
@@ -406,6 +411,36 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1340,6 +1375,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -1397,6 +1442,19 @@
         "@types/pg": "8.11.6"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1430,6 +1488,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3235,6 +3303,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3318,6 +3396,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3511,6 +3596,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
@@ -3539,6 +3630,154 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.2.tgz",
+      "integrity": "sha512-RVAi5xnqedSKvaoQyCTWvncMk8eYZcTTOsLK7XmnfOEvdGP/O/upA0/MA8Ss+Qs++mj0GcSRi/whR0S5iBPpTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.2",
+        "vitest": "3.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.2.tgz",
+      "integrity": "sha512-ipHw0z669vEMjzz3xQE8nJX1s0rQIb7oEl4jjl35qWTwm/KIHERIg/p/zORrjAaZKXfsv7IybcNGHwhOOAPMwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.2",
+        "@vitest/utils": "3.2.2",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.2.tgz",
+      "integrity": "sha512-jKojcaRyIYpDEf+s7/dD3LJt53c0dPfp5zCPXz9H/kcGrSlovU/t1yEaNzM9oFME3dcd4ULwRI/x0Po1Zf+LTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.2.tgz",
+      "integrity": "sha512-FY4o4U1UDhO9KMd2Wee5vumwcaHw7Vg4V7yR4Oq6uK34nhEJOmdRYrk3ClburPRUA09lXD/oXWZ8y/Sdma0aUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.2.tgz",
+      "integrity": "sha512-GYcHcaS3ejGRZYed2GAkvsjBeXIEerDKdX3orQrBJqLRiea4NSS9qvn9Nxmuy1IwIB+EjFOaxXnX79l8HFaBwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.2.tgz",
+      "integrity": "sha512-aMEI2XFlR1aNECbBs5C5IZopfi5Lb8QJZGGpzS8ZUHML5La5wCbrbhLOVSME68qwpT05ROEEOAZPRXFpxZV2wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.2",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.2.tgz",
+      "integrity": "sha512-6Utxlx3o7pcTxvp0u8kUiXtRFScMrUg28KjB3R2hon7w4YqOFAEA9QwzPVVS1QNL3smo4xRNOpNZClRVfpMcYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.2.tgz",
+      "integrity": "sha512-qJYMllrWpF/OYfWHP32T31QCaLa3BAzT/n/8mNGhPdVcjY+JYazQFO1nsJvXU12Kp1xMpNY4AGuljPTNjQve6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.2",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -3619,6 +3858,55 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
+      "integrity": "sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -3815,6 +4103,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -3832,6 +4130,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/camelcase-css": {
@@ -3863,6 +4174,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -3946,6 +4284,16 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3964,11 +4312,59 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
     "node_modules/colorjs.io": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "license": "MIT"
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -3977,6 +4373,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/connect-pg-simple": {
@@ -4032,6 +4438,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -4198,9 +4611,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4234,6 +4647,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4249,6 +4672,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4275,6 +4708,17 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -4879,6 +5323,20 @@
         "zod": ">=3.0.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4941,6 +5399,12 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -4951,13 +5415,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -4967,6 +5428,41 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -5041,6 +5537,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5055,6 +5561,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "4.21.2",
@@ -5203,6 +5719,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -5211,6 +5734,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -5257,6 +5786,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -5271,6 +5806,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -5366,16 +5936,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5391,6 +5966,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -5449,15 +6037,25 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -5472,10 +6070,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5484,11 +6082,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5507,6 +6109,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5579,6 +6188,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5645,11 +6260,77 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -5762,6 +6443,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -5839,6 +6526,23 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5850,6 +6554,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5877,6 +6588,56 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {
@@ -6098,6 +6859,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6172,6 +6942,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -6268,6 +7057,23 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pause": {
       "version": "0.0.1",
@@ -6969,6 +7775,20 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7152,6 +7972,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7302,6 +8131,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7312,6 +8148,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map": {
@@ -7353,6 +8198,22 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -7360,6 +8221,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -7480,6 +8357,67 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
+      "integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.1.tgz",
+      "integrity": "sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7548,6 +8486,27 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -7575,6 +8534,95 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7594,6 +8642,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -8332,6 +9389,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.2.tgz",
+      "integrity": "sha512-Xj/jovjZvDXOq2FgLXu8NsY4uHUMWtzVmMC2LkCu9HWdr9Qu1Is5sanX3Z4jOFKdohfaWDnEJWp9pRP0vVpAcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -8762,6 +9842,92 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.2.tgz",
+      "integrity": "sha512-fyNn/Rp016Bt5qvY0OQvIUCwW2vnaEBLxP42PmKbNIoasSYjML+8xyeADOPvBe+Xfl/ubIw4og7Lt9jflRsCNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.2",
+        "@vitest/mocker": "3.2.2",
+        "@vitest/pretty-format": "^3.2.2",
+        "@vitest/runner": "3.2.2",
+        "@vitest/snapshot": "3.2.2",
+        "@vitest/spy": "3.2.2",
+        "@vitest/utils": "3.2.2",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.2",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.2",
+        "@vitest/ui": "3.2.2",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8775,6 +9941,59 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wouter": {
@@ -8881,6 +10100,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -60,6 +61,7 @@
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",
+    "nodemailer": "^6.9.11",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "react": "^18.3.1",
@@ -75,6 +77,7 @@
     "vaul": "^1.1.0",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
+    "winston": "^3.10.0",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.4.0"
   },
@@ -92,14 +95,17 @@
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^4.3.2",
+    "@vitest/coverage-v8": "^3.2.2",
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "postcss": "^8.4.47",
+    "supertest": "^7.1.1",
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^3.2.1"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/initializeData.ts
+++ b/server/initializeData.ts
@@ -1,0 +1,8 @@
+import { MemStorage } from './storage';
+
+/**
+ * Create a new in-memory storage instance populated with default demo data.
+ */
+export const initializeData = (): MemStorage => {
+  return new MemStorage();
+};

--- a/server/providers/appleHealth.ts
+++ b/server/providers/appleHealth.ts
@@ -1,0 +1,69 @@
+export type AppleHealthStat = {
+  statType: string;
+  value: string;
+  unit?: string;
+  timestamp: string;
+};
+
+const APPLE_TOKEN_URL = process.env.APPLE_HEALTH_TOKEN_URL ||
+  'https://appleid.apple.com/auth/token';
+const APPLE_API_BASE = process.env.APPLE_HEALTH_API_BASE ||
+  'https://api.apple.com/health/v1';
+
+export async function exchangeAppleHealthCode(code: string, redirectUri: string) {
+  const params = new URLSearchParams({
+    client_id: process.env.APPLE_HEALTH_CLIENT_ID || '',
+    client_secret: process.env.APPLE_HEALTH_CLIENT_SECRET || '',
+    grant_type: 'authorization_code',
+    redirect_uri: redirectUri,
+    code,
+  });
+
+  const res = await fetch(APPLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to exchange Apple Health code');
+  }
+
+  return res.json();
+}
+
+export async function refreshAppleHealthToken(refreshToken: string) {
+  const params = new URLSearchParams({
+    client_id: process.env.APPLE_HEALTH_CLIENT_ID || '',
+    client_secret: process.env.APPLE_HEALTH_CLIENT_SECRET || '',
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+
+  const res = await fetch(APPLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to refresh Apple Health token');
+  }
+
+  return res.json();
+}
+
+export async function fetchAppleHealthData(accessToken: string): Promise<AppleHealthStat[]> {
+  const res = await fetch(`${APPLE_API_BASE}/metrics`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch Apple Health data');
+  }
+
+  const data = await res.json();
+  return (data.metrics || []) as AppleHealthStat[];
+}

--- a/server/providers/fitbit.ts
+++ b/server/providers/fitbit.ts
@@ -1,0 +1,83 @@
+export type FitbitStat = {
+  statType: string;
+  value: string;
+  unit?: string;
+  timestamp: string;
+};
+
+export async function fetchFitbitData(accessToken: string): Promise<FitbitStat[]> {
+  const today = new Date().toISOString().split('T')[0];
+
+  const stepsRes = await fetch(
+    `https://api.fitbit.com/1/user/-/activities/date/${today}.json`,
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  );
+  if (!stepsRes.ok) {
+    throw new Error('Failed to fetch Fitbit activities');
+  }
+  const stepsJson = await stepsRes.json();
+  const steps = stepsJson.summary?.steps || 0;
+
+  const hrRes = await fetch(
+    `https://api.fitbit.com/1/user/-/activities/heart/date/${today}/1d.json`,
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  );
+  if (!hrRes.ok) {
+    throw new Error('Failed to fetch Fitbit heart rate');
+  }
+  const hrJson = await hrRes.json();
+  const hr = hrJson['activities-heart']?.[0]?.value?.restingHeartRate;
+
+  const now = new Date().toISOString();
+  const stats: FitbitStat[] = [
+    { statType: 'steps', value: String(steps), timestamp: now },
+  ];
+  if (hr) {
+    stats.push({ statType: 'heart_rate', value: String(hr), unit: 'bpm', timestamp: now });
+  }
+  return stats;
+}
+
+export async function exchangeFitbitCode(code: string, redirectUri: string) {
+  const params = new URLSearchParams({
+    client_id: process.env.FITBIT_CLIENT_ID || '',
+    grant_type: 'authorization_code',
+    redirect_uri: redirectUri,
+    code,
+  });
+  const credentials = Buffer.from(`${process.env.FITBIT_CLIENT_ID}:${process.env.FITBIT_CLIENT_SECRET}`)
+    .toString('base64');
+  const res = await fetch('https://api.fitbit.com/oauth2/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: params.toString(),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to exchange Fitbit code');
+  }
+  return res.json();
+}
+
+export async function refreshFitbitToken(refreshToken: string) {
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+  const credentials = Buffer.from(`${process.env.FITBIT_CLIENT_ID}:${process.env.FITBIT_CLIENT_SECRET}`)
+    .toString('base64');
+  const res = await fetch('https://api.fitbit.com/oauth2/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: params.toString(),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to refresh Fitbit token');
+  }
+  return res.json();
+}

--- a/server/providers/googleFit.ts
+++ b/server/providers/googleFit.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import fs from 'fs/promises';
+
+export type GoogleFitStat = {
+  statType: string;
+  value: string;
+  unit?: string;
+  timestamp: string;
+};
+
+export async function fetchGoogleFitData(_accessToken: string): Promise<GoogleFitStat[]> {
+  // In this prototype we return mock data but a real implementation
+  // would fetch from Google Fit using the provided access token
+  const dataPath = path.resolve(__dirname, '..', '..', 'mocks', 'google-fit.json');
+  const raw = await fs.readFile(dataPath, 'utf-8');
+  return JSON.parse(raw) as GoogleFitStat[];
+}
+
+export async function exchangeGoogleFitCode(_code: string, _redirectUri: string) {
+  // In a real implementation this would exchange the authorization code for
+  // an access token using Google's OAuth endpoint
+  return {
+    access_token: 'mock-google-token',
+    refresh_token: 'mock-google-refresh',
+    expires_in: 3600,
+    scope: 'https://www.googleapis.com/auth/fitness.activity.read'
+  };
+}
+
+export async function refreshGoogleFitToken(_refreshToken: string) {
+  // Would request a new access token from Google
+  return {
+    access_token: 'mock-google-token',
+    expires_in: 3600,
+    scope: 'https://www.googleapis.com/auth/fitness.activity.read'
+  };
+}

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -1,0 +1,31 @@
+import nodemailer from 'nodemailer';
+
+const host = process.env.SMTP_HOST || 'smtp.example.com';
+const port = Number(process.env.SMTP_PORT || 587);
+const user = process.env.SMTP_USER || 'user@example.com';
+const pass = process.env.SMTP_PASS || 'password';
+const from = process.env.EMAIL_FROM || 'noreply@example.com';
+
+const transporter = nodemailer.createTransport({
+  host,
+  port,
+  secure: false,
+  auth: { user, pass }
+});
+
+export async function sendEmail(to: string, subject: string, html: string) {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+  await transporter.sendMail({ from, to, subject, html });
+}
+
+export function verificationEmailTemplate(token: string) {
+  return `<p>Verify your email by clicking the link below:</p>
+  <p><a href="${process.env.BASE_URL || 'http://localhost:5000'}/api/auth/verify-email?token=${token}">Verify Email</a></p>`;
+}
+
+export function resetPasswordEmailTemplate(token: string) {
+  return `<p>Reset your password by clicking the link below:</p>
+  <p><a href="${process.env.BASE_URL || 'http://localhost:5000'}/reset-password?token=${token}">Reset Password</a></p>`;
+}

--- a/server/utils/encryption.ts
+++ b/server/utils/encryption.ts
@@ -1,0 +1,22 @@
+import crypto from 'crypto';
+
+const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'defaultencryptionkeydefaulten';
+const IV_LENGTH = 16; // AES block size
+
+export function encrypt(text: string): string {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY.slice(0, 32)), iv);
+  let encrypted = cipher.update(text, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  return iv.toString('hex') + ':' + encrypted;
+}
+
+export function decrypt(text: string): string {
+  const [ivHex, encryptedText] = text.split(':');
+  if (!ivHex || !encryptedText) return '';
+  const iv = Buffer.from(ivHex, 'hex');
+  const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(ENCRYPTION_KEY.slice(0, 32)), iv);
+  let decrypted = decipher.update(encryptedText, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,0 +1,16 @@
+import { createLogger, format, transports } from 'winston';
+import { storage } from '../storage';
+
+export const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.printf(({ level, message, timestamp }) => `${timestamp} ${level}: ${message}`)
+  ),
+  transports: [new transports.Console()]
+});
+
+export async function logError(message: string, userId?: number, stack?: string) {
+  logger.error(message);
+  await storage.addLog({ level: 'error', message, userId, stack: stack || null, timestamp: new Date() });
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -55,7 +55,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,

--- a/shared/featureFlags.ts
+++ b/shared/featureFlags.ts
@@ -1,0 +1,12 @@
+import type { User } from './schema';
+
+export const PremiumFeatures = {
+  advancedTrendAnalysis: true,
+  exportCsv: true,
+} as const;
+
+export type PremiumFeatureKey = keyof typeof PremiumFeatures;
+
+export function hasFeature(user: User | null | undefined, feature: PremiumFeatureKey): boolean {
+  return !!user?.isPremium && PremiumFeatures[feature];
+}

--- a/tests/integration/api.failure.test.ts
+++ b/tests/integration/api.failure.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../server/providers/appleHealth', () => ({
+  fetchAppleHealthData: vi.fn().mockRejectedValue(new Error('401 Unauthorized')),
+  refreshAppleHealthToken: vi.fn(),
+  exchangeAppleHealthCode: vi.fn()
+}));
+vi.mock('../../server/providers/googleFit', () => ({
+  fetchGoogleFitData: vi.fn().mockRejectedValue(new Error('500 Provider error')),
+  refreshGoogleFitToken: vi.fn(),
+  exchangeGoogleFitCode: vi.fn()
+}));
+vi.mock('../../server/providers/fitbit', () => ({
+  fetchFitbitData: vi.fn().mockRejectedValue(new Error('500 Provider error')),
+  refreshFitbitToken: vi.fn(),
+  exchangeFitbitCode: vi.fn()
+}));
+
+import { registerRoutes } from '../../server/routes';
+
+let server: any;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  server = await registerRoutes(app);
+});
+
+afterAll(async () => {
+  if (server && server.close) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+describe('API failure handling', () => {
+  it('rejects sync when not authenticated', async () => {
+    const res = await request(server)
+      .patch('/api/health-data-connections/1/sync');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns server error when provider fetch fails', async () => {
+    const login = await request(server)
+      .post('/api/auth/login')
+      .send({ username: 'johndoe', password: 'password123' });
+    const token = login.body.token;
+
+    const res = await request(server)
+      .patch('/api/health-data-connections/1/sync')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../server/providers/appleHealth', () => ({
+  fetchAppleHealthData: vi.fn().mockResolvedValue([
+    { statType: 'steps', value: '1000', timestamp: new Date().toISOString() }
+  ]),
+  refreshAppleHealthToken: vi.fn().mockResolvedValue({ access_token: 'new', expires_in: 3600 }),
+  exchangeAppleHealthCode: vi.fn()
+}));
+vi.mock('../../server/providers/googleFit', () => ({
+  fetchGoogleFitData: vi.fn().mockResolvedValue([]),
+  refreshGoogleFitToken: vi.fn().mockResolvedValue({ access_token: 'new', expires_in: 3600 }),
+  exchangeGoogleFitCode: vi.fn()
+}));
+vi.mock('../../server/providers/fitbit', () => ({
+  fetchFitbitData: vi.fn().mockResolvedValue([]),
+  refreshFitbitToken: vi.fn().mockResolvedValue({ access_token: 'new', expires_in: 3600 }),
+  exchangeFitbitCode: vi.fn()
+}));
+
+import { registerRoutes } from '../../server/routes';
+
+let server: any;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  server = await registerRoutes(app);
+});
+
+afterAll(async () => {
+  if (server && server.close) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+describe('API integration', () => {
+  it('logs in and receives a token', async () => {
+    const res = await request(server)
+      .post('/api/auth/login')
+      .send({ username: 'johndoe', password: 'password123' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('updates health goals via profile endpoint', async () => {
+    const login = await request(server)
+      .post('/api/auth/login')
+      .send({ username: 'johndoe', password: 'password123' });
+    const token = login.body.token;
+
+    const res = await request(server)
+      .patch('/api/user/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ healthGoals: 'Run a marathon' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.healthGoals).toBe('Run a marathon');
+  });
+
+  it('syncs health data connection', async () => {
+    const login = await request(server)
+      .post('/api/auth/login')
+      .send({ username: 'johndoe', password: 'password123' });
+    const token = login.body.token;
+
+    const res = await request(server)
+      .patch('/api/health-data-connections/1/sync')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.connected).toBe(true);
+  });
+});

--- a/tests/unit/authEdgeCases.test.ts
+++ b/tests/unit/authEdgeCases.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import jwt from 'jsonwebtoken';
+import { MemStorage } from '../../server/storage';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'healthmap-secret-key';
+
+describe('authentication edge cases', () => {
+  it('fails verification for expired access token', async () => {
+    const token = jwt.sign({ id: 1 }, JWT_SECRET, { expiresIn: '1ms' });
+    await new Promise((r) => setTimeout(r, 10));
+    try {
+      jwt.verify(token, JWT_SECRET);
+      throw new Error('should have thrown');
+    } catch (err: any) {
+      expect(err.name).toBe('TokenExpiredError');
+    }
+  });
+
+  it('returns undefined for invalid refresh token', async () => {
+    const storage = new MemStorage();
+    await storage.createRefreshToken({
+      userId: 1,
+      token: 'valid',
+      expiresAt: new Date(Date.now() + 1000),
+      revoked: false,
+    });
+    const missing = await storage.getRefreshToken('invalid');
+    expect(missing).toBeUndefined();
+  });
+
+  it('rejects tampered JWT payloads', () => {
+    const token = jwt.sign({ id: 1, username: 'user' }, JWT_SECRET);
+    const parts = token.split('.');
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    payload.id = 2;
+    parts[1] = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    const tampered = parts.join('.');
+    expect(() => jwt.verify(tampered, JWT_SECRET)).toThrow();
+  });
+});

--- a/tests/unit/featureFlags.test.ts
+++ b/tests/unit/featureFlags.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { hasFeature } from '../../shared/featureFlags';
+import type { User } from '../../shared/schema';
+
+const baseUser: Omit<User, 'id'> = {
+  username: 'test',
+  password: 'x',
+  email: 'a@b.c',
+  name: 'Test',
+  profilePicture: null as any,
+  healthData: null as any,
+  isPremium: false,
+  emailVerified: true,
+  verificationToken: null,
+  passwordResetToken: null,
+  passwordResetExpires: null,
+};
+
+describe('hasFeature', () => {
+  it('allows premium user', () => {
+    const user: User = { id: 1, ...baseUser, isPremium: true };
+    expect(hasFeature(user, 'advancedTrendAnalysis')).toBe(true);
+  });
+
+  it('denies standard user', () => {
+    const user: User = { id: 2, ...baseUser, isPremium: false };
+    expect(hasFeature(user, 'exportCsv')).toBe(false);
+  });
+});

--- a/tests/unit/initializeData.test.ts
+++ b/tests/unit/initializeData.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { initializeData } from '../../server/initializeData';
+import { MemStorage } from '../../server/storage';
+
+describe('initializeData', () => {
+  it('returns an initialized MemStorage instance', () => {
+    const storage = initializeData();
+    expect(storage).toBeInstanceOf(MemStorage);
+  });
+});

--- a/tests/unit/refreshToken.test.ts
+++ b/tests/unit/refreshToken.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { MemStorage } from '../../server/storage';
+
+describe('refresh token flow', () => {
+  it('creates and revokes tokens', async () => {
+    const store = new MemStorage();
+    const token = await store.createRefreshToken({
+      userId: 1,
+      token: 'abc',
+      expiresAt: new Date(Date.now() + 1000),
+      revoked: false,
+    });
+    const fetched = await store.getRefreshToken('abc');
+    expect(fetched?.id).toBe(token.id);
+    await store.revokeRefreshToken('abc');
+    const revoked = await store.getRefreshToken('abc');
+    expect(revoked?.revoked).toBe(true);
+  });
+});

--- a/tests/unit/transformHealthData.test.ts
+++ b/tests/unit/transformHealthData.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { transformHealthData } from '../../client/src/lib/transformHealthData';
+
+function isoDaysAgo(days: number) {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString();
+}
+
+describe('transformHealthData', () => {
+  it('returns empty array for no stats', () => {
+    expect(transformHealthData([])).toEqual([]);
+  });
+
+  it('groups stats by date and parses numeric values', () => {
+    const day = isoDaysAgo(1);
+    const stats = [
+      { timestamp: day, statType: 'steps', value: '100' },
+      { timestamp: day, statType: 'heart_rate', value: '70' }
+    ];
+    const result = transformHealthData(stats);
+    const entry = result.find(d => d.date === day.split('T')[0]);
+    expect(entry).toMatchObject({ steps: 100, heartRate: 70 });
+  });
+
+  it('handles undefined input', () => {
+    expect(transformHealthData(undefined as any)).toEqual([]);
+  });
+
+  it('ignores records with bad timestamps', () => {
+    const stats = [
+      { timestamp: 'invalid', statType: 'steps', value: '50' },
+      { timestamp: isoDaysAgo(0), statType: 'steps', value: '25' }
+    ];
+    const result = transformHealthData(stats);
+    expect(result.some(r => r.steps === 25)).toBe(true);
+  });
+
+  it('skips unknown stat types', () => {
+    const stats = [
+      { timestamp: isoDaysAgo(0), statType: 'unknown', value: '10' },
+      { timestamp: isoDaysAgo(0), statType: 'steps', value: '5' }
+    ];
+    const result = transformHealthData(stats);
+    const today = isoDaysAgo(0).split('T')[0];
+    const entry = result.find(r => r.date === today);
+    expect(entry?.steps).toBe(5);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'client', 'src'),
+      '@shared': path.resolve(__dirname, 'shared')
+    }
+  },
+  test: {
+    include: [
+      'client/src/components/__tests__/*.ts',
+      'tests/unit/**/*.test.ts',
+      'tests/integration/**/*.test.ts'
+    ],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      all: true
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- track sessions and metrics via new database tables
- add Winston logger for backend errors
- log sync activity and auth events
- expose metrics API and client admin dashboard
- update navigation to link to admin page

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68409fda62248326aca009b9c9fb7dec